### PR TITLE
SMSのリンク先を修正

### DIFF
--- a/components/evidence-sticky.tsx
+++ b/components/evidence-sticky.tsx
@@ -17,7 +17,7 @@ export default function EvidenceSticky() {
             <Typography component="h3" variant="body1">効果</Typography>
             <Typography component="h3" variant="body1">
               証拠の強さ
-              <Link href={`/EBPMDB/sms${ext}`}><Help sx={{ position: 'relative', top: '6px' }} /></Link>
+              <Link href={`/EBPMDB/sms`}><Help sx={{ position: 'relative', top: '6px' }} /></Link>
             </Typography>
           </Box>
         </CardContent>


### PR DESCRIPTION
# やったこと
evidenceカードの?マークをクリックしてもSMSページに行かないようになっていたのでリンクを修正
