### PR TITLE
トップ以外のページのタイトルとfaviconを表示

### DIFF
--- a/_local/serve.js
+++ b/_local/serve.js
@@ -3,10 +3,14 @@ const http = require('http');
 
 const server = http.createServer((request, response) => {
   const destUrl = request.url.replace('/EBPMDB', '')
+  const slugUrl = destUrl.replace('%5Bslug%5D', '[slug]')
   return handler(request, response, {
     public: "./out/",
     rewrites: [
-      { source: "/EBPMDB/_next/**", destination: `${destUrl}` }
+      { source: "/EBPMDB/_next/static/chunks/pages/doc/**.js", destination: `${slugUrl}`},
+      { source: "/EBPMDB/_next/**", destination: `${destUrl}` },
+      { source: "/EBPMDB/**.{png,jpg,svg}", destination: `${destUrl}` },
+      { source: "/EBPMDB/site.webmanifest", destination: `${destUrl}` },
     ],
     redirects: [
       { source: "/EBPMDB", destination: `${destUrl}` },

--- a/components/header.js
+++ b/components/header.js
@@ -1,32 +1,37 @@
 import Head from 'next/head';
+import Script from 'next/script'
 
-const Header = () => (
-  <div>
+const Header = (props) => {
+  const {
+    title="",
+    description="EBPMデータベースは、証拠に基づく政策を推進するためのプラットフォームです。"
+  } = props
+
+  return (
     <Head>
-
-    <script async src={`https://www.googletagmanager.com/gtag/js?id=G-PZVWLS7B4E`} />
-              <script
-                dangerouslySetInnerHTML={{
-                  __html: `
-                  window.dataLayer = window.dataLayer || [];
-                  function gtag(){dataLayer.push(arguments);}
-                  gtag('js', new Date());
-                  gtag('config', 'G-PZVWLS7B4E', {
-                    page_path: window.location.pathname,
-                  });`,
-                }}
-              />
-
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png"/>
-            <link rel="icon" type="image/png" sizes="32x32" href="/EBPMDB/favicon-32x32.png"/>
-            <link rel="icon" type="image/png" sizes="16x16" href="/EBPMDB/favicon-16x16.png"/>
-            <link rel="manifest" href="/EBPMDB/site.webmanifest"/>
-            <link rel="mask-icon" href="/EBPMDB/safari-pinned-tab.svg" color="#5bbad5"/>
-            <meta name="msapplication-TileColor" content="#da532c"/>
-            <meta name="theme-color" content="#ffffff"/>   
-            <title>EBPMデータベース</title>
+      <Script async src={`https://www.googletagmanager.com/gtag/js?id=G-PZVWLS7B4E`} />
+      <Script
+        dangerouslySetInnerHTML={{
+          __html: `
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-PZVWLS7B4E', {
+            page_path: window.location.pathname,
+          });`,
+        }}
+      />
+      <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png"/>
+      <link rel="icon" type="image/png" sizes="32x32" href="/EBPMDB/favicon-32x32.png"/>
+      <link rel="icon" type="image/png" sizes="16x16" href="/EBPMDB/favicon-16x16.png"/>
+      <link rel="manifest" href="/EBPMDB/site.webmanifest"/>
+      <link rel="mask-icon" href="/EBPMDB/safari-pinned-tab.svg" color="#5bbad5"/>
+      <meta name="msapplication-TileColor" content="#da532c"/>
+      <meta name="theme-color" content="#ffffff"/>
+      <title>{`${title + (title !== '' ? ' | ' : '')}EBPMデータベース`}</title>
+      <meta name='description' content={description} />
     </Head>
-  </div>
-);
+  )
+};
 
 export default Header

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,26 +1,12 @@
-import Head from 'next/head';
+import Head from 'next/head'
 import Script from 'next/script'
 
-const Header = (props) => {
-  const {
-    title="",
-    description="EBPMデータベースは、証拠に基づく政策を推進するためのプラットフォームです。"
-  } = props
-
-  return (
+const Header = ({
+  title="",
+  description="EBPMデータベースは、証拠に基づく政策を推進するためのプラットフォームです。"
+}) => (
+  <>
     <Head>
-      <Script async src={`https://www.googletagmanager.com/gtag/js?id=G-PZVWLS7B4E`} />
-      <Script
-        dangerouslySetInnerHTML={{
-          __html: `
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', 'G-PZVWLS7B4E', {
-            page_path: window.location.pathname,
-          });`,
-        }}
-      />
       <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png"/>
       <link rel="icon" type="image/png" sizes="32x32" href="/EBPMDB/favicon-32x32.png"/>
       <link rel="icon" type="image/png" sizes="16x16" href="/EBPMDB/favicon-16x16.png"/>
@@ -31,7 +17,20 @@ const Header = (props) => {
       <title>{`${title + (title !== '' ? ' | ' : '')}EBPMデータベース`}</title>
       <meta name='description' content={description} />
     </Head>
-  )
-};
+    <Script async src={`https://www.googletagmanager.com/gtag/js?id=G-PZVWLS7B4E`} />
+    <Script
+      id='google-analytics-script'
+      dangerouslySetInnerHTML={{
+        __html: `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-PZVWLS7B4E', {
+          page_path: window.location.pathname,
+        });`,
+      }}
+    />
+  </>
+)
 
 export default Header

--- a/pages/committee.tsx
+++ b/pages/committee.tsx
@@ -175,7 +175,7 @@ const committee: FunctionComponent = () => {
 
   return (
     <>
-      <Header title="運営主体について" description="" />
+      <Header title="運営主体について" />
       <Navigation />
       <Container sx={{ m: 'auto', width: '100%', maxWidth: 1024 }}>
         <Typography component='h1' variant='h4' sx={{ marginTop: '2em' }}>

--- a/pages/committee.tsx
+++ b/pages/committee.tsx
@@ -1,3 +1,4 @@
+import Header from '../components/header'
 import Navigation from '../components/navigation'
 import Footer from '../components/footer'
 import cyberagentLogoSrc from '../public/images/cyberagent_logo.png'
@@ -174,6 +175,7 @@ const committee: FunctionComponent = () => {
 
   return (
     <>
+      <Header title="運営主体について" description="" />
       <Navigation />
       <Container sx={{ m: 'auto', width: '100%', maxWidth: 1024 }}>
         <Typography component='h1' variant='h4' sx={{ marginTop: '2em' }}>

--- a/pages/doc/[slug].tsx
+++ b/pages/doc/[slug].tsx
@@ -1,3 +1,4 @@
+import Header from '../../components/header'
 import { FunctionComponent } from 'react'
 import fs from 'fs'
 import matter from 'gray-matter'
@@ -17,6 +18,7 @@ interface IProps {
 const Document: FunctionComponent<IProps> = ({ doc }) => {
   return (
     <>
+      <Header title={doc.meta.title} description={doc.meta.description} />
       <Navigation />
       <Container sx={{ m: 'auto', width: '100%', maxWidth: 1024 }}>
         <Typography component="h1" variant="h4" sx={{ marginTop: '2em' }}>

--- a/pages/effectiveness.tsx
+++ b/pages/effectiveness.tsx
@@ -1,3 +1,4 @@
+import Header from '../components/header'
 import Navigation from '../components/navigation'
 import { Container } from '@mui/material'
 import { Typography, Grid, Link } from '@mui/material'
@@ -8,6 +9,7 @@ import { FunctionComponent } from 'react'
 const SMS: FunctionComponent = () => {
   return (
     <>
+      <Header title="効果について" description="" />
       <Navigation />
       <Container sx={{ m: 'auto' }}>
         <Typography component="h2" variant="h2" sx={{ my: 8 }}>

--- a/pages/effectiveness.tsx
+++ b/pages/effectiveness.tsx
@@ -9,7 +9,7 @@ import { FunctionComponent } from 'react'
 const SMS: FunctionComponent = () => {
   return (
     <>
-      <Header title="効果について" description="" />
+      <Header title="効果について" />
       <Navigation />
       <Container sx={{ m: 'auto' }}>
         <Typography component="h2" variant="h2" sx={{ my: 8 }}>

--- a/pages/sms.tsx
+++ b/pages/sms.tsx
@@ -1,3 +1,4 @@
+import Header from '../components/header'
 import Navigation from '../components/navigation'
 import { Container } from '@mui/material'
 import { Typography, Grid, Link } from '@mui/material'
@@ -8,6 +9,7 @@ import { FunctionComponent } from 'react'
 const SMS: FunctionComponent = () => {
   return (
     <>
+      <Header title="証拠の強さについて" description="" />
       <Navigation />
       <Container sx={{ m: 'auto' }}>
         <Typography component="h2" variant="h2" sx={{ my: 8 }}>

--- a/pages/sms.tsx
+++ b/pages/sms.tsx
@@ -9,7 +9,7 @@ import { FunctionComponent } from 'react'
 const SMS: FunctionComponent = () => {
   return (
     <>
-      <Header title="証拠の強さについて" description="" />
+      <Header title="証拠の強さについて" />
       <Navigation />
       <Container sx={{ m: 'auto' }}>
         <Typography component="h2" variant="h2" sx={{ my: 8 }}>


### PR DESCRIPTION
#61 の対応です。
他のコンポーネントに合わせて`header.js`を`header.tsx`に変更しています。