### PR TITLE
ci: upgrade to Node.js 22 and opt into Node.js 24 actions runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       - name: Install NPM packages
         run: npm ci


### PR DESCRIPTION
## Summary

- `node-version` を `20.x` → `22.x`（現行 LTS）に更新
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` を workflow env に追加し、Action 本体のランタイムを Node.js 24 に今すぐ切り替え

## 背景

build ジョブで以下の警告が発生していた（issue #177）：

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Test plan

- [ ] CI が正常に完了することを確認
- [ ] GitHub Pages へのデプロイが成功することを確認

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)