### PR TITLE
refactor: remove @material-ui/icons@4 in favor of @mui/icons-material@5

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
-# Required until @material-ui/icons@4 is migrated to @mui/icons-material@5 (see issue #175).
-# @material-ui/icons@4 has an unresolved peer dependency conflict with React 18.
+# Required due to @mui/styles@5 requiring @types/react@^17.0.0 while the project uses @types/react@^18.0.0.
 legacy-peer-deps=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-# Required due to @mui/styles@5 requiring react@^17.0.0 and @types/react@^17.0.0 while the project uses React 18.
+# Required because @mui/styles@5.10.10 declares peer dependencies on react@^17.0.0 and @types/react@^17.0.0, while the project uses React 18 and @types/react@^18.0.0.
 legacy-peer-deps=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-# Required due to @mui/styles@5 requiring @types/react@^17.0.0 while the project uses @types/react@^18.0.0.
+# Required due to @mui/styles@5 requiring react@^17.0.0 and @types/react@^17.0.0 while the project uses React 18.
 legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
-        "@material-ui/icons": "^4.11.3",
         "@mui/icons-material": "^5.10.9",
         "@mui/material": "^5.10.13",
         "@mui/styles": "^5.10.10",
@@ -967,28 +966,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@material-ui/icons": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.3.tgz",
-      "integrity": "sha512-IKHlyx6LDh8n19vzwH5RtHIOHl9Tu90aAAxcbWME6kp4dmvODM3UvOHJeMIDzUbd4muuJKHmlNoBN+mDY4XkBA==",
-      "dependencies": {
-        "@babel/runtime": "^7.4.4"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@material-ui/core": "^4.0.0",
-        "@types/react": "^16.8.6 || ^17.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@mui/base": {
@@ -9260,14 +9237,6 @@
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
       "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "optional": true
-    },
-    "@material-ui/icons": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.3.tgz",
-      "integrity": "sha512-IKHlyx6LDh8n19vzwH5RtHIOHl9Tu90aAAxcbWME6kp4dmvODM3UvOHJeMIDzUbd4muuJKHmlNoBN+mDY4XkBA==",
-      "requires": {
-        "@babel/runtime": "^7.4.4"
-      }
     },
     "@mui/base": {
       "version": "5.0.0-alpha.105",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@material-ui/icons": "^4.11.3",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.13",
     "@mui/styles": "^5.10.10",


### PR DESCRIPTION
## Summary

- `@material-ui/icons@4` (EOL) を `package.json` から削除
- ソースコード上のインポートは既に `@mui/icons-material@5` のみを使用していたため、コード変更は不要だった
- `.npmrc` のコメントを更新（`legacy-peer-deps` は `@mui/styles@5` が `react@^17.0.0` と `@types/react@^17.0.0` を要求するのに対しプロジェクトが React 18 を使用しているため引き続き必要）

Closes #175

## Test plan

- [x] `npm install` が正常完了
- [x] `npm run build` が正常完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)